### PR TITLE
Fix tests to work on modern Rakudo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /src/*.o
 /src/Makefile
 /.panda-work
+lib/.precomp

--- a/t/010_f.t
+++ b/t/010_f.t
@@ -3,21 +3,38 @@ use Test;
 use IO::Capture::Simple;
 use Log::Minimal;
 
+my $DATETIME = rx/
+    (<[+-]>? \d**4 \d*)                            # year
+    '-'
+    (\d\d)                                         # month
+    '-'
+    (\d\d)                                         # day
+    <[Tt]>                                         # time separator
+    (\d\d)                                         # hour
+    ':'
+    (\d\d)                                         # minute
+    ':'
+    (\d\d[<[\.,]>\d ** 1..6]?)                     # second
+    (<[Zz]> || (<[\-\+]>) (\d\d) (':'? (\d\d))? )? # timezone
+/;
+my $FILE = 't/010_f.t';
+
 my $log = Log::Minimal.new(:timezone(0));
 
 subtest {
     {
+        use Grammar::Tracer;
         my $out = capture_stderr {
             $log.critf('critical');
         };
-        like $out, rx{^<[0..9]> ** 4\-<[0..9]> ** 2\-<[0..9]> ** 2T<[0..9]> ** 2\:<[0..9]> ** 2\:<[0..9]> ** 2Z' '\[CRITICAL\]' 'critical' 'at' 't\/010_f\.t' 'line' '11\n$};
+        like $out, rx{^<$DATETIME>" [CRITICAL] critical at $FILE line "<{$?LINE - 2}>\n$};
     }
 
     {
         my $out = capture_stderr {
             $log.critf('critical:%s', 'foo');
         };
-        like $out, rx{^<[0..9]> ** 4\-<[0..9]> ** 2\-<[0..9]> ** 2T<[0..9]> ** 2\:<[0..9]> ** 2\:<[0..9]> ** 2Z' '\[CRITICAL\]' 'critical\:foo' 'at' 't\/010_f\.t' 'line' '18\n$};
+        like $out, rx{^<$DATETIME>" [CRITICAL] critical:foo at $FILE line "<{$?LINE - 2}>\n$};
     }
 }, 'test for critf';
 
@@ -26,14 +43,14 @@ subtest {
         my $out = capture_stderr {
             $log.warnf('warn');
         };
-        like $out, rx{^<[0..9]> ** 4\-<[0..9]> ** 2\-<[0..9]> ** 2T<[0..9]> ** 2\:<[0..9]> ** 2\:<[0..9]> ** 2Z' '\[WARN\]' 'warn' 'at' 't\/010_f\.t' 'line' '27\n$};
+        like $out, rx{^<$DATETIME>" [WARN] warn at $FILE line "<{$?LINE - 2}>\n$};
     }
 
     {
         my $out = capture_stderr {
             $log.warnf('warn:%s', 'foo');
         };
-        like $out, rx{^<[0..9]> ** 4\-<[0..9]> ** 2\-<[0..9]> ** 2T<[0..9]> ** 2\:<[0..9]> ** 2\:<[0..9]> ** 2Z' '\[WARN\]' 'warn\:foo' 'at' 't\/010_f\.t' 'line' '34\n$};
+        like $out, rx{^<$DATETIME>" [WARN] warn:foo at $FILE line "<{$?LINE - 2}>\n$};
     }
 }, 'test for warnf';
 
@@ -42,14 +59,14 @@ subtest {
         my $out = capture_stderr {
             $log.infof('info');
         };
-        like $out, rx{^<[0..9]> ** 4\-<[0..9]> ** 2\-<[0..9]> ** 2T<[0..9]> ** 2\:<[0..9]> ** 2\:<[0..9]> ** 2Z' '\[INFO\]' 'info' 'at' 't\/010_f\.t' 'line' '43\n$};
+        like $out, rx{^<$DATETIME>" [INFO] info at $FILE line "<{$?LINE - 2}>\n$};
     }
 
     {
         my $out = capture_stderr {
             $log.infof('info:%s', 'foo');
         };
-        like $out, rx{^<[0..9]> ** 4\-<[0..9]> ** 2\-<[0..9]> ** 2T<[0..9]> ** 2\:<[0..9]> ** 2\:<[0..9]> ** 2Z' '\[INFO\]' 'info\:foo' 'at' 't\/010_f\.t' 'line' '50\n$};
+        like $out, rx{^<$DATETIME>" [INFO] info:foo at $FILE line "<{$?LINE - 2}>\n$};
     }
 }, 'test for infof';
 
@@ -59,14 +76,14 @@ subtest {
         my $out = capture_stderr {
             $log.debugf('debug');
         };
-        like $out, rx{^<[0..9]> ** 4\-<[0..9]> ** 2\-<[0..9]> ** 2T<[0..9]> ** 2\:<[0..9]> ** 2\:<[0..9]> ** 2Z' '\[DEBUG\]' 'debug' 'at' 't\/010_f\.t' 'line' '60\n$};
+        like $out, rx{^<$DATETIME>" [DEBUG] debug at $FILE line "<{$?LINE - 2}>\n$};
     }
 
     {
         my $out = capture_stderr {
             $log.debugf('debug:%s', 'foo');
         };
-        like $out, rx{^<[0..9]> ** 4\-<[0..9]> ** 2\-<[0..9]> ** 2T<[0..9]> ** 2\:<[0..9]> ** 2\:<[0..9]> ** 2Z' '\[DEBUG\]' 'debug\:foo' 'at' 't\/010_f\.t' 'line' '67\n$};
+        like $out, rx{^<$DATETIME>" [DEBUG] debug:foo at $FILE line "<{$?LINE - 2}>\n$};
     }
 }, 'test for debugf';
 

--- a/t/020_ff.t
+++ b/t/020_ff.t
@@ -3,27 +3,43 @@ use Test;
 use IO::Capture::Simple;
 use Log::Minimal;
 
+my $DATETIME = rx/
+    (<[+-]>? \d**4 \d*)                            # year
+    '-'
+    (\d\d)                                         # month
+    '-'
+    (\d\d)                                         # day
+    <[Tt]>                                         # time separator
+    (\d\d)                                         # hour
+    ':'
+    (\d\d)                                         # minute
+    ':'
+    (\d\d[<[\.,]>\d ** 1..6]?)                     # second
+    (<[Zz]> || (<[\-\+]>) (\d\d) (':'? (\d\d))? )? # timezone
+/;
+my $FILE = 't/020_ff.t';
+
 my $log = Log::Minimal.new(:timezone(0));
 
 subtest {
     my $out = capture_stderr {
         $log.critff('critical');
     };
-    like $out, rx{^<[0..9]> ** 4\-<[0..9]> ** 2\-<[0..9]> ** 2T<[0..9]> ** 2\:<[0..9]> ** 2\:<[0..9]> ** 2Z' '\[CRITICAL\]' 'critical' 'at' 't\/020_ff\.t' 'line' '10 ',' .+\n$};
+    like $out, rx{^<$DATETIME>" [CRITICAL] critical at $FILE line "<{$?LINE - 2}> \, .+$};
 }, 'test for critf';
 
 subtest {
     my $out = capture_stderr {
         $log.warnff('warn');
     };
-    like $out, rx{^<[0..9]> ** 4\-<[0..9]> ** 2\-<[0..9]> ** 2T<[0..9]> ** 2\:<[0..9]> ** 2\:<[0..9]> ** 2Z' '\[WARN\]' 'warn' 'at' 't\/020_ff\.t' 'line' '17 ',' .+\n$};
+    like $out, rx{^<$DATETIME>" [WARN] warn at $FILE line "<{$?LINE - 2}> \, .+$};
 }, 'test for warnff';
 
 subtest {
     my $out = capture_stderr {
         $log.infoff('info');
     };
-    like $out, rx{^<[0..9]> ** 4\-<[0..9]> ** 2\-<[0..9]> ** 2T<[0..9]> ** 2\:<[0..9]> ** 2\:<[0..9]> ** 2Z' '\[INFO\]' 'info' 'at' 't\/020_ff\.t' 'line' '24 ',' .+\n$};
+    like $out, rx{^<$DATETIME>" [INFO] info at $FILE line "<{$?LINE - 2}> \, .+$};
 }, 'test for infoff';
 
 subtest {
@@ -31,7 +47,7 @@ subtest {
     my $out = capture_stderr {
         $log.debugff('debug');
     };
-    like $out, rx{^<[0..9]> ** 4\-<[0..9]> ** 2\-<[0..9]> ** 2T<[0..9]> ** 2\:<[0..9]> ** 2\:<[0..9]> ** 2Z' '\[DEBUG\]' 'debug' 'at' 't\/020_ff\.t' 'line' '32 ',' .+\n$};
+    like $out, rx{^<$DATETIME>" [DEBUG] debug at $FILE line "<{$?LINE - 2}> \, .+$};
 }, 'test for debugff';
 
 subtest {
@@ -41,4 +57,3 @@ subtest {
 }, 'test for errorff';
 
 done-testing;
-

--- a/t/040_escape-white-space.t
+++ b/t/040_escape-white-space.t
@@ -3,12 +3,28 @@ use Test;
 use IO::Capture::Simple;
 use Log::Minimal;
 
+my $DATETIME = rx/
+    (<[+-]>? \d**4 \d*)                            # year
+    '-'
+    (\d\d)                                         # month
+    '-'
+    (\d\d)                                         # day
+    <[Tt]>                                         # time separator
+    (\d\d)                                         # hour
+    ':'
+    (\d\d)                                         # minute
+    ':'
+    (\d\d[<[\.,]>\d ** 1..6]?)                     # second
+    (<[Zz]> || (<[\-\+]>) (\d\d) (':'? (\d\d))? )? # timezone
+/;
+my $FILE = 't/040_escape-white-space.t';
+
 subtest {
     my $log = Log::Minimal.new(:timezone(0));
     my $out = capture_stderr {
         $log.critf("s\r\n\te");
     };
-    like $out, rx{^<[0..9]> ** 4\-<[0..9]> ** 2\-<[0..9]> ** 2T<[0..9]> ** 2\:<[0..9]> ** 2\:<[0..9]> ** 2Z' '\[CRITICAL\]' 's\\r\\n\\te' 'at' 't'/'040_escape'-'white'-'space'.'t' 'line' '9\n$};
+    like $out, rx{^<$DATETIME>" [CRITICAL] s\r\n\\te at $FILE line "<{$?LINE - 2}>\n$};
 }, 'default, escape white space';
 
 subtest {
@@ -16,7 +32,8 @@ subtest {
     my $out = capture_stderr {
         $log.critf("s\r\n\te");
     };
-    like $out, rx{^<[0..9]> ** 4\-<[0..9]> ** 2\-<[0..9]> ** 2T<[0..9]> ** 2\:<[0..9]> ** 2\:<[0..9]> ** 2Z' '\[CRITICAL\]' 's\r\n\te' 'at' 't'/'040_escape'-'white'-'space'.'t' 'line' '17\n$};
+    like $out, rx{^<$DATETIME>" [CRITICAL] s\r\n\te at $FILE line "<{$?LINE - 2}>\n$};
+    # like $out, rx{^<$DATETIME>' '\[CRITICAL\]' 's\r\n\te' 'at' 't'/'040_escape'-'white'-'space'.'t' 'line' '17\n$};
 }, 'do not escape white space';
 
 done-testing;

--- a/t/050_color.t
+++ b/t/050_color.t
@@ -3,6 +3,22 @@ use Test;
 use IO::Capture::Simple;
 use Log::Minimal;
 
+my $DATETIME = rx/
+    (<[+-]>? \d**4 \d*)                            # year
+    '-'
+    (\d\d)                                         # month
+    '-'
+    (\d\d)                                         # day
+    <[Tt]>                                         # time separator
+    (\d\d)                                         # hour
+    ':'
+    (\d\d)                                         # minute
+    ':'
+    (\d\d[<[\.,]>\d ** 1..6]?)                     # second
+    (<[Zz]> || (<[\-\+]>) (\d\d) (':'? (\d\d))? )? # timezone
+/;
+my $FILE = 't/050_color.t';
+
 %*ENV<LM_COLOR> = True;
 my $log = Log::Minimal.new(:timezone(0));
 
@@ -11,7 +27,7 @@ subtest {
         $log.critf('critical');
     };
 
-    if $out ~~ m{^<[0..9]> ** 4\-<[0..9]> ** 2\-<[0..9]> ** 2T<[0..9]> ** 2\:<[0..9]> ** 2\:<[0..9]> ** 2Z' '\[CRITICAL\]' '(.+)' 'at' 't\/050_color\.t' 'line' '11\n$} {
+    if $out ~~ m{^<$DATETIME>" [CRITICAL] "(.+)" at $FILE line "<{$?LINE - 3}>\n$} {
         is $0, "\x[1b][30;41mcritical\x[1b][0m";
     } else {
         ok False, 'Not matched to regex';
@@ -23,7 +39,7 @@ subtest {
         $log.warnf('warn');
     };
 
-    if $out ~~ rx{^<[0..9]> ** 4\-<[0..9]> ** 2\-<[0..9]> ** 2T<[0..9]> ** 2\:<[0..9]> ** 2\:<[0..9]> ** 2Z' '\[WARN\]' '(.+)' 'at' 't\/050_color\.t' 'line' '23\n$} {
+    if $out ~~ m{^<$DATETIME>" [WARN] "(.+)" at $FILE line "<{$?LINE - 3}>\n$} {
         is $0, "\x[1b][30;43mwarn\x[1b][0m";
     } else {
         ok False, 'Not matched to regex';
@@ -35,7 +51,7 @@ subtest {
         $log.infof('info');
     };
 
-    if $out ~~ rx{^<[0..9]> ** 4\-<[0..9]> ** 2\-<[0..9]> ** 2T<[0..9]> ** 2\:<[0..9]> ** 2\:<[0..9]> ** 2Z' '\[INFO\]' '(.+)' 'at' 't\/050_color\.t' 'line' '35\n$} {
+    if $out ~~ m{^<$DATETIME>" [INFO] "(.+)" at $FILE line "<{$?LINE - 3}>\n$} {
         is $0, "\x[1b][32minfo\x[1b][0m";
     } else {
         ok False, 'Not matched to regex';
@@ -48,7 +64,7 @@ subtest {
         $log.debugf('debug');
     };
 
-    if $out ~~ rx{^<[0..9]> ** 4\-<[0..9]> ** 2\-<[0..9]> ** 2T<[0..9]> ** 2\:<[0..9]> ** 2\:<[0..9]> ** 2Z' '\[DEBUG\]' '(.+)' 'at' 't\/050_color\.t' 'line' '48\n$} {
+    if $out ~~ m{^<$DATETIME>" [DEBUG] "(.+)" at $FILE line "<{$?LINE - 3}>\n$} {
         is $0, "\x[1b][31;47mdebug\x[1b][0m";
     } else {
         ok False, 'Not matched to regex';

--- a/t/060_default-trace-level.t
+++ b/t/060_default-trace-level.t
@@ -3,12 +3,28 @@ use Test;
 use IO::Capture::Simple;
 use Log::Minimal;
 
+my $DATETIME = rx/
+    (<[+-]>? \d**4 \d*)                            # year
+    '-'
+    (\d\d)                                         # month
+    '-'
+    (\d\d)                                         # day
+    <[Tt]>                                         # time separator
+    (\d\d)                                         # hour
+    ':'
+    (\d\d)                                         # minute
+    ':'
+    (\d\d[<[\.,]>\d ** 1..6]?)                     # second
+    (<[Zz]> || (<[\-\+]>) (\d\d) (':'? (\d\d))? )? # timezone
+/;
+my $FILE = 't/060_default-trace-level.t';
+
 subtest {
     my $log = Log::Minimal.new(:default-trace-level(2), :timezone(0));
     my $out = capture_stderr {
         $log.critf('critical');
     };
-    like $out, rx{^<[0..9]> ** 4\-<[0..9]> ** 2\-<[0..9]> ** 2T<[0..9]> ** 2\:<[0..9]> ** 2\:<[0..9]> ** 2Z' '\[CRITICAL\]' 'critical' 'at' 't\/060_default\-trace\-level\.t' 'line' '8\n$}
+    like $out, rx{^<$DATETIME>" [CRITICAL] critical at $FILE line "<{$?LINE - 3}>\n$};
 }, 'test for default-trace-level';
 
 done-testing;

--- a/t/080_custom-format.t
+++ b/t/080_custom-format.t
@@ -3,6 +3,22 @@ use Test;
 use IO::Capture::Simple;
 use Log::Minimal;
 
+my $DATETIME = rx/
+    (<[+-]>? \d**4 \d*)                            # year
+    '-'
+    (\d\d)                                         # month
+    '-'
+    (\d\d)                                         # day
+    <[Tt]>                                         # time separator
+    (\d\d)                                         # hour
+    ':'
+    (\d\d)                                         # minute
+    ':'
+    (\d\d[<[\.,]>\d ** 1..6]?)                     # second
+    (<[Zz]> || (<[\-\+]>) (\d\d) (':'? (\d\d))? )? # timezone
+/;
+my $FILE = 't/080_custom-format.t';
+
 subtest {
     my $log = Log::Minimal.new(:timezone(0));
     $log.print = sub (:$time, :$log-level, :$messages, :$trace) {
@@ -12,7 +28,7 @@ subtest {
     my $out = capture_stderr {
         $log.warnf('msg');
     }
-    like $out, rx{at' 't\/080_custom\-format\.t' 'line' '13' 'msg' '\[WARN\]' '<[0..9]> ** 4\-<[0..9]> ** 2\-<[0..9]> ** 2T<[0..9]> ** 2\:<[0..9]> ** 2\:<[0..9]> ** 2Z\n$}
+    like $out, rx{"at $FILE line "<{$?LINE - 2}>' msg [WARN] '<$DATETIME>\n};
 }, 'custom print';
 
 done-testing;

--- a/t/100_timezone.t
+++ b/t/100_timezone.t
@@ -3,6 +3,22 @@ use Test;
 use IO::Capture::Simple;
 use Log::Minimal;
 
+my $DATETIME = rx/
+    (<[+-]>? \d**4 \d*)                            # year
+    '-'
+    (\d\d)                                         # month
+    '-'
+    (\d\d)                                         # day
+    <[Tt]>                                         # time separator
+    (\d\d)                                         # hour
+    ':'
+    (\d\d)                                         # minute
+    ':'
+    (\d\d[<[\.,]>\d ** 1..6]?)                     # second
+    (<[\-\+]>) (\d\d) (':'? (\d\d))?     # MANDATORY non-UTC timezone
+/;
+my $FILE = 't/100_timezone.t';
+
 my $timezone = DateTime.new('2015-12-24T12:23:00+0900').timezone;
 my $log = Log::Minimal.new(:$timezone);
 
@@ -10,7 +26,8 @@ subtest {
     my $out = capture_stderr {
         $log.critf('critical');
     };
-    like $out, rx{^<[0..9]> ** 4\-<[0..9]> ** 2\-<[0..9]> ** 2T<[0..9]> ** 2\:<[0..9]> ** 2\:<[0..9]> ** 2\+09\:00' '\[CRITICAL\]' 'critical' 'at' 't\/100_timezone\.t' 'line' '11\n$};
+    like $out, rx{^<$DATETIME>" [CRITICAL] critical at $FILE line "<{$?LINE - 2}>\n$};
+        #like $out, rx{^<[0..9]> ** 4\-<[0..9]> ** 2\-<[0..9]> ** 2T<[0..9]> ** 2\:<[0..9]> ** 2\:<[0..9]> ** 2\+09\:00' '\[CRITICAL\]' 'critical' 'at' 't\/100_timezone\.t' 'line' '11\n$};
 }, 'test for critf';
 
 done-testing;


### PR DESCRIPTION
Somewhere along the line, turning a DateTime object into a Str changed
formats. I updated this format, using the validation pattern for
matching the ISO-8601-style timestamps used in Rakudo.

I also reformatted the regexes for matching to be clearer, and used a
variable for referencing line numbers rather than hardcoding a line
number in the message.