### PR TITLE
Several fixes

### DIFF
--- a/lib/Log/Minimal.pm6
+++ b/lib/Log/Minimal.pm6
@@ -113,9 +113,8 @@ method !log(LogLevel $log-level, Bool $full-trace, Bool $die, *@text) {
     }
 
     if ($.escape-whitespace) {
-        $messages = $messages.subst(/\x0d/, '\r', :g);
-        $messages = $messages.subst(/\x0a/, '\n', :g);
-        $messages = $messages.subst(/\x09/, '\t', :g);
+		$messages = $messages.encode>>.&{ { 13 => '\r', 10 => '\n', 9 => '\t' }{$_} || $_.chr }.join;
+		# $messages.=subst(/<[\r\n\t]>/, { sprintf('\\x%02x', $_.ord) }, :g)
     }
 
     if ($.color) {

--- a/lib/Log/Minimal.pm6
+++ b/lib/Log/Minimal.pm6
@@ -94,7 +94,10 @@ method !log(LogLevel $log-level, Bool $full-trace, Bool $die, *@text) {
         }
         CATCH {
             when 'ctxcaller needs an MVMContext' {
-                $trace = 'at ' ~ @bts[0..*-2].map(-> $bt {sprintf('%s line %s', $bt.file, $bt.line)}).join(', ');
+                $trace = 'at ' ~ @bts[0..*-2]
+					.grep({ $_.annotations ~~ Hash })
+					.map(-> $bt {sprintf('%s line %s', $bt.file, $bt.line)})
+					.join(', ');
             }
         }
     } else {

--- a/t/010_f.t
+++ b/t/010_f.t
@@ -5,19 +5,21 @@ use Log::Minimal;
 
 my $log = Log::Minimal.new(:timezone(0));
 
+my regex timestamp { \d ** 4 '-' \d ** 2 '-' \d ** 2 'T' \d ** 2 ':' \d ** 2 ':' \d ** 2 '.' \d+ 'Z' };
+
 subtest {
     {
         my $out = capture_stderr {
             $log.critf('critical');
         };
-        like $out, rx{^<[0..9]> ** 4\-<[0..9]> ** 2\-<[0..9]> ** 2T<[0..9]> ** 2\:<[0..9]> ** 2\:<[0..9]> ** 2Z' '\[CRITICAL\]' 'critical' 'at' 't\/010_f\.t' 'line' '11\n$};
+        like $out, rx{^ <timestamp> ' [CRITICAL] critical at t/010_f.t line 13' \n $};
     }
 
     {
         my $out = capture_stderr {
             $log.critf('critical:%s', 'foo');
         };
-        like $out, rx{^<[0..9]> ** 4\-<[0..9]> ** 2\-<[0..9]> ** 2T<[0..9]> ** 2\:<[0..9]> ** 2\:<[0..9]> ** 2Z' '\[CRITICAL\]' 'critical\:foo' 'at' 't\/010_f\.t' 'line' '18\n$};
+        like $out, rx{^ <timestamp> ' [CRITICAL] critical:foo at t/010_f.t line 20' \n $};
     }
 }, 'test for critf';
 
@@ -26,14 +28,14 @@ subtest {
         my $out = capture_stderr {
             $log.warnf('warn');
         };
-        like $out, rx{^<[0..9]> ** 4\-<[0..9]> ** 2\-<[0..9]> ** 2T<[0..9]> ** 2\:<[0..9]> ** 2\:<[0..9]> ** 2Z' '\[WARN\]' 'warn' 'at' 't\/010_f\.t' 'line' '27\n$};
+        like $out, rx{^ <timestamp> ' [WARN] warn at t/010_f.t line 29' \n $};
     }
 
     {
         my $out = capture_stderr {
             $log.warnf('warn:%s', 'foo');
         };
-        like $out, rx{^<[0..9]> ** 4\-<[0..9]> ** 2\-<[0..9]> ** 2T<[0..9]> ** 2\:<[0..9]> ** 2\:<[0..9]> ** 2Z' '\[WARN\]' 'warn\:foo' 'at' 't\/010_f\.t' 'line' '34\n$};
+		like $out, rx{^ <timestamp> ' [WARN] warn:foo at t/010_f.t line 36' \n $};
     }
 }, 'test for warnf';
 
@@ -42,14 +44,14 @@ subtest {
         my $out = capture_stderr {
             $log.infof('info');
         };
-        like $out, rx{^<[0..9]> ** 4\-<[0..9]> ** 2\-<[0..9]> ** 2T<[0..9]> ** 2\:<[0..9]> ** 2\:<[0..9]> ** 2Z' '\[INFO\]' 'info' 'at' 't\/010_f\.t' 'line' '43\n$};
+		like $out, rx{^ <timestamp> ' [INFO] info at t/010_f.t line 45' \n $};
     }
 
     {
         my $out = capture_stderr {
             $log.infof('info:%s', 'foo');
         };
-        like $out, rx{^<[0..9]> ** 4\-<[0..9]> ** 2\-<[0..9]> ** 2T<[0..9]> ** 2\:<[0..9]> ** 2\:<[0..9]> ** 2Z' '\[INFO\]' 'info\:foo' 'at' 't\/010_f\.t' 'line' '50\n$};
+		like $out, rx{^ <timestamp> ' [INFO] info:foo at t/010_f.t line 52' \n $};
     }
 }, 'test for infof';
 
@@ -59,14 +61,14 @@ subtest {
         my $out = capture_stderr {
             $log.debugf('debug');
         };
-        like $out, rx{^<[0..9]> ** 4\-<[0..9]> ** 2\-<[0..9]> ** 2T<[0..9]> ** 2\:<[0..9]> ** 2\:<[0..9]> ** 2Z' '\[DEBUG\]' 'debug' 'at' 't\/010_f\.t' 'line' '60\n$};
+		like $out, rx{^ <timestamp> ' [DEBUG] debug at t/010_f.t line 62' \n $};
     }
 
     {
         my $out = capture_stderr {
             $log.debugf('debug:%s', 'foo');
         };
-        like $out, rx{^<[0..9]> ** 4\-<[0..9]> ** 2\-<[0..9]> ** 2T<[0..9]> ** 2\:<[0..9]> ** 2\:<[0..9]> ** 2Z' '\[DEBUG\]' 'debug\:foo' 'at' 't\/010_f\.t' 'line' '67\n$};
+		like $out, rx{^ <timestamp> ' [DEBUG] debug:foo at t/010_f.t line 69' \n $};
     }
 }, 'test for debugf';
 

--- a/t/020_ff.t
+++ b/t/020_ff.t
@@ -5,25 +5,27 @@ use Log::Minimal;
 
 my $log = Log::Minimal.new(:timezone(0));
 
+my regex timestamp { \d ** 4 '-' \d ** 2 '-' \d ** 2 'T' \d ** 2 ':' \d ** 2 ':' \d ** 2 '.' \d+ 'Z' };
+
 subtest {
     my $out = capture_stderr {
         $log.critff('critical');
     };
-    like $out, rx{^<[0..9]> ** 4\-<[0..9]> ** 2\-<[0..9]> ** 2T<[0..9]> ** 2\:<[0..9]> ** 2\:<[0..9]> ** 2Z' '\[CRITICAL\]' 'critical' 'at' 't\/020_ff\.t' 'line' '10 ',' .+\n$};
+    like $out, rx{^ <timestamp> ' [CRITICAL] critical at t/020_ff.t line 12, ' .+ \n $};
 }, 'test for critf';
 
 subtest {
     my $out = capture_stderr {
         $log.warnff('warn');
     };
-    like $out, rx{^<[0..9]> ** 4\-<[0..9]> ** 2\-<[0..9]> ** 2T<[0..9]> ** 2\:<[0..9]> ** 2\:<[0..9]> ** 2Z' '\[WARN\]' 'warn' 'at' 't\/020_ff\.t' 'line' '17 ',' .+\n$};
+    like $out, rx{^ <timestamp> ' [WARN] warn at t/020_ff.t line 19, ' .+ \n $};
 }, 'test for warnff';
 
 subtest {
     my $out = capture_stderr {
         $log.infoff('info');
     };
-    like $out, rx{^<[0..9]> ** 4\-<[0..9]> ** 2\-<[0..9]> ** 2T<[0..9]> ** 2\:<[0..9]> ** 2\:<[0..9]> ** 2Z' '\[INFO\]' 'info' 'at' 't\/020_ff\.t' 'line' '24 ',' .+\n$};
+    like $out, rx{^ <timestamp> ' [INFO] info at t/020_ff.t line 26, ' .+ \n $};
 }, 'test for infoff';
 
 subtest {
@@ -31,7 +33,7 @@ subtest {
     my $out = capture_stderr {
         $log.debugff('debug');
     };
-    like $out, rx{^<[0..9]> ** 4\-<[0..9]> ** 2\-<[0..9]> ** 2T<[0..9]> ** 2\:<[0..9]> ** 2\:<[0..9]> ** 2Z' '\[DEBUG\]' 'debug' 'at' 't\/020_ff\.t' 'line' '32 ',' .+\n$};
+    like $out, rx{^ <timestamp> ' [DEBUG] debug at t/020_ff.t line 34, ' .+ \n $};
 }, 'test for debugff';
 
 subtest {

--- a/t/040_escape-white-space.t
+++ b/t/040_escape-white-space.t
@@ -3,12 +3,14 @@ use Test;
 use IO::Capture::Simple;
 use Log::Minimal;
 
+my regex timestamp { \d ** 4 '-' \d ** 2 '-' \d ** 2 'T' \d ** 2 ':' \d ** 2 ':' \d ** 2 '.' \d+ 'Z' };
+
 subtest {
     my $log = Log::Minimal.new(:timezone(0));
     my $out = capture_stderr {
         $log.critf("s\r\n\te");
     };
-    like $out, rx{^<[0..9]> ** 4\-<[0..9]> ** 2\-<[0..9]> ** 2T<[0..9]> ** 2\:<[0..9]> ** 2\:<[0..9]> ** 2Z' '\[CRITICAL\]' 's\\r\\n\\te' 'at' 't'/'040_escape'-'white'-'space'.'t' 'line' '9\n$};
+    like $out, rx{^ <timestamp> ' [CRITICAL] s\\r\\n\\te at t/040_escape-white-space.t line 11' \n $};
 }, 'default, escape white space';
 
 subtest {
@@ -16,7 +18,7 @@ subtest {
     my $out = capture_stderr {
         $log.critf("s\r\n\te");
     };
-    like $out, rx{^<[0..9]> ** 4\-<[0..9]> ** 2\-<[0..9]> ** 2T<[0..9]> ** 2\:<[0..9]> ** 2\:<[0..9]> ** 2Z' '\[CRITICAL\]' 's\r\n\te' 'at' 't'/'040_escape'-'white'-'space'.'t' 'line' '17\n$};
+    like $out, rx{^ <timestamp> " [CRITICAL] s\r\n\te at t/040_escape-white-space.t line 19" \n $};
 }, 'do not escape white space';
 
 done-testing;

--- a/t/050_color.t
+++ b/t/050_color.t
@@ -3,6 +3,8 @@ use Test;
 use IO::Capture::Simple;
 use Log::Minimal;
 
+my regex timestamp { \d ** 4 '-' \d ** 2 '-' \d ** 2 'T' \d ** 2 ':' \d ** 2 ':' \d ** 2 '.' \d+ 'Z' };
+
 %*ENV<LM_COLOR> = True;
 my $log = Log::Minimal.new(:timezone(0));
 
@@ -11,9 +13,10 @@ subtest {
         $log.critf('critical');
     };
 
-    if $out ~~ m{^<[0..9]> ** 4\-<[0..9]> ** 2\-<[0..9]> ** 2T<[0..9]> ** 2\:<[0..9]> ** 2\:<[0..9]> ** 2Z' '\[CRITICAL\]' '(.+)' 'at' 't\/050_color\.t' 'line' '11\n$} {
+    if $out ~~ m{^ <timestamp> ' [CRITICAL] ' (.+) ' at t/050_color.t line 13' \n $} {
         is $0, "\x[1b][30;41mcritical\x[1b][0m";
     } else {
+		$0.encode.note;
         ok False, 'Not matched to regex';
     };
 }, 'test for critf';
@@ -23,7 +26,7 @@ subtest {
         $log.warnf('warn');
     };
 
-    if $out ~~ rx{^<[0..9]> ** 4\-<[0..9]> ** 2\-<[0..9]> ** 2T<[0..9]> ** 2\:<[0..9]> ** 2\:<[0..9]> ** 2Z' '\[WARN\]' '(.+)' 'at' 't\/050_color\.t' 'line' '23\n$} {
+    if $out ~~ rx{^ <timestamp> ' [WARN] ' (.+) ' at t/050_color.t line 26' \n $} {
         is $0, "\x[1b][30;43mwarn\x[1b][0m";
     } else {
         ok False, 'Not matched to regex';
@@ -35,7 +38,7 @@ subtest {
         $log.infof('info');
     };
 
-    if $out ~~ rx{^<[0..9]> ** 4\-<[0..9]> ** 2\-<[0..9]> ** 2T<[0..9]> ** 2\:<[0..9]> ** 2\:<[0..9]> ** 2Z' '\[INFO\]' '(.+)' 'at' 't\/050_color\.t' 'line' '35\n$} {
+    if $out ~~ rx{^ <timestamp> ' [INFO] ' (.+) ' at t/050_color.t line 38' \n $} {
         is $0, "\x[1b][32minfo\x[1b][0m";
     } else {
         ok False, 'Not matched to regex';
@@ -48,7 +51,7 @@ subtest {
         $log.debugf('debug');
     };
 
-    if $out ~~ rx{^<[0..9]> ** 4\-<[0..9]> ** 2\-<[0..9]> ** 2T<[0..9]> ** 2\:<[0..9]> ** 2\:<[0..9]> ** 2Z' '\[DEBUG\]' '(.+)' 'at' 't\/050_color\.t' 'line' '48\n$} {
+    if $out ~~ rx{^ <timestamp> ' [DEBUG] ' (.+) ' at t/050_color.t line 51' \n $} {
         is $0, "\x[1b][31;47mdebug\x[1b][0m";
     } else {
         ok False, 'Not matched to regex';

--- a/t/060_default-trace-level.t
+++ b/t/060_default-trace-level.t
@@ -3,12 +3,14 @@ use Test;
 use IO::Capture::Simple;
 use Log::Minimal;
 
+my regex timestamp { \d ** 4 '-' \d ** 2 '-' \d ** 2 'T' \d ** 2 ':' \d ** 2 ':' \d ** 2 '.' \d+ 'Z' };
+
 subtest {
     my $log = Log::Minimal.new(:default-trace-level(2), :timezone(0));
     my $out = capture_stderr {
         $log.critf('critical');
     };
-    like $out, rx{^<[0..9]> ** 4\-<[0..9]> ** 2\-<[0..9]> ** 2T<[0..9]> ** 2\:<[0..9]> ** 2\:<[0..9]> ** 2Z' '\[CRITICAL\]' 'critical' 'at' 't\/060_default\-trace\-level\.t' 'line' '8\n$}
+    like $out, rx{^ <timestamp> ' [CRITICAL] critical at t/060_default-trace-level.t line 10' \n $}
 }, 'test for default-trace-level';
 
 done-testing;

--- a/t/080_custom-format.t
+++ b/t/080_custom-format.t
@@ -3,6 +3,8 @@ use Test;
 use IO::Capture::Simple;
 use Log::Minimal;
 
+my regex timestamp { \d ** 4 '-' \d ** 2 '-' \d ** 2 'T' \d ** 2 ':' \d ** 2 ':' \d ** 2 '.' \d+ 'Z' };
+
 subtest {
     my $log = Log::Minimal.new(:timezone(0));
     $log.print = sub (:$time, :$log-level, :$messages, :$trace) {
@@ -12,7 +14,7 @@ subtest {
     my $out = capture_stderr {
         $log.warnf('msg');
     }
-    like $out, rx{at' 't\/080_custom\-format\.t' 'line' '13' 'msg' '\[WARN\]' '<[0..9]> ** 4\-<[0..9]> ** 2\-<[0..9]> ** 2T<[0..9]> ** 2\:<[0..9]> ** 2\:<[0..9]> ** 2Z\n$}
+    like $out, rx{'at t/080_custom-format.t line 15 msg [WARN] ' <timestamp> \n $}
 }, 'custom print';
 
 done-testing;

--- a/t/090_autodump.t
+++ b/t/090_autodump.t
@@ -3,13 +3,15 @@ use Test;
 use IO::Capture::Simple;
 use Log::Minimal;
 
+my regex timestamp { \d ** 4 '-' \d ** 2 '-' \d ** 2 'T' \d ** 2 ':' \d ** 2 ':' \d ** 2 '.' \d+ 'Z' };
+
 subtest {
     {
         my $log = Log::Minimal.new(:autodump(True), :timezone(0));
         my $out = capture_stderr {
             $log.critf({foo => 'bar'});
         };
-        like $out, rx{^<[0..9]> ** 4\-<[0..9]> ** 2\-<[0..9]> ** 2T<[0..9]> ** 2\:<[0..9]> ** 2\:<[0..9]> ** 2Z' '\[CRITICAL\]' '\:foo\(\"bar\"\)' 'at' 't\/090_autodump\.t' 'line' '10\n$};
+        like $out, rx{^ <timestamp>  ' [CRITICAL] :foo("bar") at t/090_autodump.t line 12' \n $};
     }
 
     {
@@ -20,7 +22,7 @@ subtest {
             my $out = capture_stderr {
                 $log.critf('%s', {foo => 'bar'});
             };
-            like $out, rx{^<[0..9]> ** 4\-<[0..9]> ** 2\-<[0..9]> ** 2T<[0..9]> ** 2\:<[0..9]> ** 2\:<[0..9]> ** 2Z' '\[CRITICAL\]' '\:foo\(\"bar\"\)' 'at' 't\/090_autodump\.t' 'line' '21\n$};
+            like $out, rx{^ <timestamp> ' [CRITICAL] :foo("bar") at t/090_autodump.t line 23' \n $};
         }
         is $log.autodump, False;
     }

--- a/t/100_timezone.t
+++ b/t/100_timezone.t
@@ -3,6 +3,8 @@ use Test;
 use IO::Capture::Simple;
 use Log::Minimal;
 
+my regex timestamp { \d ** 4 '-' \d ** 2 '-' \d ** 2 'T' \d ** 2 ':' \d ** 2 ':' \d ** 2 '.' \d+ '+09:00' };
+
 my $timezone = DateTime.new('2015-12-24T12:23:00+0900').timezone;
 my $log = Log::Minimal.new(:$timezone);
 
@@ -10,7 +12,7 @@ subtest {
     my $out = capture_stderr {
         $log.critf('critical');
     };
-    like $out, rx{^<[0..9]> ** 4\-<[0..9]> ** 2\-<[0..9]> ** 2T<[0..9]> ** 2\:<[0..9]> ** 2\:<[0..9]> ** 2\+09\:00' '\[CRITICAL\]' 'critical' 'at' 't\/100_timezone\.t' 'line' '11\n$};
+    like $out, rx{^ <timestamp> ' [CRITICAL] critical at t/100_timezone.t line 13' \n $};
 }, 'test for critf';
 
 done-testing;


### PR DESCRIPTION
The module didn't build because of several bugs and outdated/broken (?) tests.

* The timestamps include milliseconds which the regexes in the tests did not expect.
* There was a crash when building the stack trace because some callframes don't have `.annotations`
* Escaping whitespaces failed because of how "\r\n" in strings is handled internally. They're now escaped on byte-level, don't know how smart this is but it works.

Please review carefully. The tests succeed, but I didn't test the module extensively other than that.